### PR TITLE
JENKINS-19090 can't delete the project

### DIFF
--- a/src/main/java/jenkins/plugins/util/ReadUtil.java
+++ b/src/main/java/jenkins/plugins/util/ReadUtil.java
@@ -19,15 +19,25 @@ public class ReadUtil {
     private static final Logger LOGGER = Logger.getLogger(ReadUtil.class.getName());
 
     public static Properties getJobProperties(Job job) {
+        FileInputStream fs = null;
         try {
             File rootDir = job.getRootDir();
             File file = new File(rootDir.getAbsolutePath() + File.separator + StoreUtil.BANGKOU_PROPERTIES);
+            fs = new FileInputStream(file);
             Properties properties = new Properties();
-            properties.load(new FileInputStream(file));
+            properties.load(fs);
             return properties;
         } catch (IOException e) {
             LOGGER.warning(String.format("get property file error : %s", e.getMessage()));
             return null;
+        } finally {
+            if (fs != null) {
+                try {
+                    fs.close();
+                } catch (IOException e) {
+                    LOGGER.warning(String.format("error while closing the stream: %s", e.getMessage()));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
load(InputStream) method leave the stream open after using it so I just add a finally block for closing it. That open stream could leave the file opened.

java.nio.file.FileSystemException: D:\00_CI\00_Jenkins\jobs\test\mttr.properties: The process cannot access the file because it is being used by another process.

@zhaozhiming Are you still maintaining the plugin? 

@reviewbybees cc/ @aheritier 